### PR TITLE
CI: Upload static site build artifacts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,13 @@ jobs:
 
       - run: touch packages/demo/out/.nojekyll
 
+      - name: Upload static site artifact
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: adb-tools-static-site
+          path: packages/demo/out
+
       - name: Deploy
         uses: s0/git-publish-subdir-action@develop
         env:


### PR DESCRIPTION
This PR updates the CI workflow to upload the static site build output as an artifact.

Workflow edited: .github/workflows/deploy.yml

What changed:
- Added an actions/upload-artifact@v4 step in the build job right before the existing Deploy step.
- Artifact name: adb-tools-static-site
- Artifact path: packages/demo/out (produced by `npx next export` in packages/demo and used by the deploy action)

How to download:
- Open the relevant Actions run for this workflow
- In the Artifacts section, download the artifact named "adb-tools-static-site"

Output directory confirmation:
- The workflow runs `npx next export` in packages/demo and deploys `packages/demo/out`; the same directory is uploaded as the artifact.

No unrelated steps were changed; existing pnpm setup and deploy behavior remain intact.