### PR TITLE
Feature: Add ?showSidebar=true|false to toggle sidebar

### DIFF
--- a/packages/demo/src/pages/_app.tsx
+++ b/packages/demo/src/pages/_app.tsx
@@ -137,7 +137,30 @@ function App({ Component, pageProps }: AppProps) {
         setLeftPanelVisible((value) => !value);
     }, []);
     useEffect(() => {
-        setLeftPanelVisible(innerWidth > 650);
+        let paramValue: boolean | undefined = undefined;
+        try {
+            const search = window.location.search;
+            if (search) {
+                const sp = new URLSearchParams(search);
+                const raw = sp.get('showSidebar');
+                if (raw !== null) {
+                    const v = raw.trim().toLowerCase();
+                    if (v === 'true') {
+                        paramValue = true;
+                    } else if (v === 'false') {
+                        paramValue = false;
+                    }
+                    // invalid values are ignored
+                }
+            }
+        } catch {
+            // ignore parsing errors
+        }
+        if (paramValue !== undefined) {
+            setLeftPanelVisible(paramValue);
+        } else {
+            setLeftPanelVisible(innerWidth > 650);
+        }
     }, []);
 
     const router = useRouter();

--- a/packages/demo/src/pages/index.mdx
+++ b/packages/demo/src/pages/index.mdx
@@ -48,6 +48,10 @@ One USB device can only be accessed by one application at a time. Please make su
 
 Extra software is required to bridge the connection. See <ExternalLink href="https://github.com/yume-chan/ya-webadb/discussions/245#discussioncomment-384030">this discussion</ExternalLink>.
 
+## URL parameters
+
+- showSidebar=true|false: Controls visibility of the left sidebar. Values are case-insensitive. When absent or invalid, the app uses its existing default behavior.
+
 export default ({ children }) => (
     <div style={{ height: "100%", padding: "0 16px", overflow: "auto" }}>
         <Head>


### PR DESCRIPTION
Summary
- Adds a URL query parameter `showSidebar` to control visibility of the left sidebar in the demo app.
- Accepted values: `true` or `false` (case-insensitive).
- When the parameter is absent or has an invalid value, existing default behavior is preserved.

Details
- Parsed once on client during app initialization in `packages/demo/src/pages/_app.tsx` and wired into the existing `leftPanelVisible` state.
- Defaults to previous behavior (visible on width > 650px) when the param is not provided or invalid.
- No changes to SSR/exported HTML are required; value is applied post-hydration.

Docs
- Updated `packages/demo/src/pages/index.mdx` with a new "URL parameters" section describing `showSidebar` usage.

Testing
- Verified build passes for the workspace and the demo package.
- Manually verify:
  - `?showSidebar=true` shows the sidebar
  - `?showSidebar=false` hides the sidebar
  - No parameter leaves behavior unchanged.
