### PR TITLE
demo: fix Next build type error (ReadableStream/WritableStream mismatch)

### DIFF
--- a/packages/demo/src/components/tabby-frame-manager.tsx
+++ b/packages/demo/src/components/tabby-frame-manager.tsx
@@ -61,8 +61,14 @@ class AdbProxyTransportServerImpl implements AdbProxyTransportServer {
             socket.writable
         ).bePipedThroughFrom(new WrapConsumableStream());
         callback(
-            Comlink.transfer(socket.readable, [socket.readable]),
-            Comlink.transfer(writable, [writable]),
+            Comlink.transfer(
+                socket.readable as unknown as ReadableStream<Uint8Array>,
+                [socket.readable as unknown as ReadableStream<Uint8Array>]
+            ),
+            Comlink.transfer(
+                writable as unknown as WritableStream<Uint8Array>,
+                [writable as unknown as WritableStream<Uint8Array>]
+            ),
             Comlink.proxy(() => socket.close())
         );
     }


### PR DESCRIPTION
Fixes the failing CI build in packages/demo by aligning stream types used with Comlink transfer.

- File: packages/demo/src/components/tabby-frame-manager.tsx
- Change: Cast the readable/writable streams to the DOM ReadableStream/WritableStream types that Next/TS expects during build.
- Reason: next build failed with a type error in tabby-frame-manager.tsx complaining that the polyfilled web-streams types are not assignable to the DOM ReadableStream types exposed via lib.dom. This adjusts the types at the callsite to satisfy TS.

This is a minimal, local types-only change and does not alter runtime behavior.
