### PR TITLE
demo: fix Next build error – message event type guard

### DIFF
--- a/packages/demo/src/pages/chrome-devtools.tsx
+++ b/packages/demo/src/pages/chrome-devtools.tsx
@@ -307,8 +307,9 @@ const ChromeDevToolsPage: NextPage = observer(function ChromeDevTools() {
         childWindow.addEventListener("message", (e) => {
             if (
                 typeof e.data !== "object" ||
-                !"type in e.data" ||
-                e.data.type !== "AdbWebSocket"
+                e.data === null ||
+                !("type" in e.data) ||
+                (e.data as any).type !== "AdbWebSocket"
             ) {
                 return;
             }


### PR DESCRIPTION
Fixes Next build error in packages/demo/src/pages/chrome-devtools.tsx.

- Correct the message event type guard: check typeof e.data === 'object', e.data !== null, and ('type' in e.data) before comparing the value. This replaces an always-truthy check.

This is a types/guard-only change; no runtime behavior changes intended.