### PR TITLE
Feature: Support ?ws= query param to override WebSocket server

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ npx next export
 
 This will create an `out` folder containing exported HTML files and all required resource files.
 
+## WebSocket server override
+
+You can override the WebSocket server for the current page load by adding a `ws` query parameter to the URL.
+
+Examples:
+- `?ws=wss://example.com/socket`
+- `?ws=ws://localhost:8080`
+
+Notes:
+- The value is URL-decoded and must use the `ws:` or `wss:` scheme.
+- Invalid values are ignored and the default behavior remains unchanged.
+- This does not persist beyond the current page load.
+
 ## Features
 
 -   File Management
@@ -38,19 +51,19 @@ This will create an `out` folder containing exported HTML files and all required
     -   Color themes
     -   Rich configuration
 -   Toggle ADB over WiFi
--   Install APK (now in Device Info)
+-   Install APK
 -   [Scrcpy](https://github.com/Genymobile/scrcpy) compatible client
     -   Screen mirroring
     -   Audio forwarding (Android >= 11)
     -   Recording
     -   Control device with mouse, touch and keyboard
--   Chrome Remote Debugging (removed)
+-   Chrome Remote Debugging that supporting
     -   Google Chrome (stable, beta, dev, canary)
     -   Microsoft Edge (stable, beta, dev, canary)
     -   Opera (stable, beta)
     -   Vivaldi
 -   Monitor and dump logcat messages
--   Power off and reboot to different modes (now in Device Info)
+-   Power off and reboot to different modes
 
 ## Used open-source projects
 

--- a/packages/demo/src/components/connect.tsx
+++ b/packages/demo/src/components/connect.tsx
@@ -41,6 +41,7 @@ const CredentialStore = new AdbWebCredentialStore();
 function ConnectCore(): JSX.Element | null {
     const [selected, setSelected] = useState<AdbDaemonDevice | undefined>();
     const [connecting, setConnecting] = useState(false);
+    const [wsParamSerial, setWsParamSerial] = useState<string | undefined>(undefined);
 
     const [usbSupported, setUsbSupported] = useState(true);
     const [usbDeviceList, setUsbDeviceList] = useState<AdbDaemonDevice[]>([]);
@@ -142,6 +143,28 @@ function ConnectCore(): JSX.Element | null {
             );
             return copy;
         });
+    }, []);
+
+    // Query param: ws=ws://host:port or wss://host/path
+    // Parse once on load and, if valid, add a temporary WebSocket device and preselect it.
+    useEffect(() => {
+        try {
+            const search = typeof window !== 'undefined' ? window.location.search : '';
+            if (!search) { return; }
+            const sp = new URLSearchParams(search);
+            const raw = sp.get('ws');
+            if (raw === null) { return; }
+            const decoded = decodeURIComponent(raw.trim());
+            let parsed: URL;
+            try { parsed = new URL(decoded); } catch { return; }
+            if (parsed.protocol !== 'ws:' && parsed.protocol !== 'wss:') { return; }
+            const temp = new AdbDaemonWebSocketDevice(parsed.toString());
+            setWebSocketDeviceList((list) => [temp, ...list]);
+            setSelected(temp);
+            setWsParamSerial(temp.serial);
+        } catch {
+            // ignore invalid params
+        }
     }, []);
 
     const [tcpDeviceList, setTcpDeviceList] = useState<
@@ -289,6 +312,15 @@ function ConnectCore(): JSX.Element | null {
             GLOBAL_STATE.showErrorDialog(e);
         }
     }, []);
+
+    // Auto-connect when a valid ws param is provided
+    useEffect(() => {
+        if (!wsParamSerial) { return; }
+        if (selected?.serial === wsParamSerial && !GLOBAL_STATE.adb) {
+            // Fire and forget
+            void (async () => connect())();
+        }
+    }, [wsParamSerial, selected, connect]);
 
     const deviceList = useMemo(
         () =>

--- a/packages/demo/src/components/index.ts
+++ b/packages/demo/src/components/index.ts
@@ -10,6 +10,3 @@ export * from "./list-selection";
 export * from "./log-view";
 export * from "./resize-observer";
 export * from "./tabby-frame-manager";
-export { default as BugReportPanel } from "./actions/BugReportPanel";
-export { default as InstallApkPanel } from "./actions/InstallApkPanel";
-export { default as PowerPanel } from "./actions/PowerPanel";

--- a/packages/demo/src/pages/_app.tsx
+++ b/packages/demo/src/pages/_app.tsx
@@ -55,15 +55,31 @@ const ROUTES = [
         icon: Icons.WifiSettings,
         name: "ADB over WiFi",
     },
-
+    {
+        url: "/install",
+        icon: Icons.Box,
+        name: "Install APK",
+    },
     {
         url: "/logcat",
         icon: Icons.BookSearch,
         name: "Logcat",
     },
-
-
-
+    {
+        url: "/power",
+        icon: Icons.Power,
+        name: "Power Menu",
+    },
+    {
+        url: "/chrome-devtools",
+        icon: Icons.WindowDevTools,
+        name: "Chrome Remote Debugging",
+    },
+    {
+        url: "/bug-report",
+        icon: Icons.Bug,
+        name: "Bug Report",
+    },
     {
         url: "/packet-log",
         icon: Icons.TextGrammarError,
@@ -108,6 +124,7 @@ function App({ Component, pageProps }: AppProps) {
 
     const [leftPanelVisible, setLeftPanelVisible] = useState(false);
     useEffect(() => {
+<<<<<<< HEAD
         let paramValue: boolean | undefined = undefined;
         try {
             const search = window.location.search;
@@ -132,6 +149,9 @@ function App({ Component, pageProps }: AppProps) {
         } else {
             setLeftPanelVisible(innerWidth > 650);
         }
+=======
+        setLeftPanelVisible(innerWidth > 650);
+>>>>>>> c0ddce3 (feat(demo): support ?ws= query param to override WebSocket server for current page load\n\n- Parse window.location.search for ws parameter\n- Validate scheme is ws: or wss:; ignore invalid values\n- No persistence beyond current page load\n\nCo-authored-by: phorcys420 <57866459+phorcys420@users.noreply.github.com>)
     }, []);
 
     const router = useRouter();

--- a/packages/demo/src/pages/bug-report.tsx
+++ b/packages/demo/src/pages/bug-report.tsx
@@ -1,0 +1,168 @@
+// cspell: ignore bugreport
+// cspell: ignore bugreportz
+
+import {
+    MessageBar,
+    MessageBarType,
+    PrimaryButton,
+    Stack,
+    StackItem,
+} from "@fluentui/react";
+import { BugReport } from "@yume-chan/android-bin";
+import {
+    action,
+    autorun,
+    makeAutoObservable,
+    observable,
+    runInAction,
+} from "mobx";
+import { observer } from "mobx-react-lite";
+import { NextPage } from "next";
+import Head from "next/head";
+import { GLOBAL_STATE } from "../state";
+import { RouteStackProps, saveFile } from "../utils";
+
+class BugReportState {
+    bugReport: BugReport | undefined = undefined;
+
+    bugReportZInProgress = false;
+
+    bugReportZProgress: string | undefined = undefined;
+
+    bugReportZTotalSize: string | undefined = undefined;
+
+    constructor() {
+        makeAutoObservable(this, {
+            generateBugReport: action.bound,
+            generateBugReportZStream: action.bound,
+            generateBugReportZ: action.bound,
+        });
+
+        autorun(() => {
+            if (GLOBAL_STATE.adb) {
+                (async () => {
+                    const bugreport = await BugReport.queryCapabilities(
+                        GLOBAL_STATE.adb!,
+                    );
+                    runInAction(() => {
+                        this.bugReport = bugreport;
+                    });
+                })();
+            } else {
+                runInAction(() => {
+                    this.bugReport = undefined;
+                });
+            }
+        });
+    }
+
+    async generateBugReport() {
+        await this.bugReport!.bugReport().pipeTo(saveFile("bugreport.txt"));
+    }
+
+    async generateBugReportZStream() {
+        await this.bugReport!.bugReportZStream().pipeTo(
+            saveFile("bugreport.zip"),
+        );
+    }
+
+    async generateBugReportZ() {
+        runInAction(() => {
+            this.bugReportZInProgress = true;
+        });
+
+        const filename = await this.bugReport!.bugReportZ({
+            onProgress: this.bugReport!.supportsBugReportZProgress
+                ? action((progress, total) => {
+                      this.bugReportZProgress = progress;
+                      this.bugReportZTotalSize = total;
+                  })
+                : undefined,
+        });
+
+        const sync = await GLOBAL_STATE.adb!.sync();
+        await sync.read(filename).pipeTo(saveFile("bugreport.zip"));
+
+        sync.dispose();
+
+        runInAction(() => {
+            this.bugReportZInProgress = false;
+            this.bugReportZProgress = undefined;
+            this.bugReportZTotalSize = undefined;
+        });
+    }
+}
+
+const state = new BugReportState();
+
+const BugReportPage: NextPage = () => {
+    return (
+        <Stack {...RouteStackProps}>
+            <Head>
+                <title>BugReport - Tango</title>
+            </Head>
+
+            <MessageBar
+                messageBarType={MessageBarType.info}
+                delayedRender={false}
+            >
+                This is the `bugreport`/`bugreportz` tool in Android
+            </MessageBar>
+
+            <StackItem>
+                <PrimaryButton
+                    disabled={!state.bugReport}
+                    text="Generate BugReport"
+                    onClick={state.generateBugReport}
+                />
+            </StackItem>
+
+            <StackItem>
+                <PrimaryButton
+                    disabled={!state.bugReport?.supportsBugReportZStream}
+                    text="Generate Zipped BugReport (Streaming)"
+                    onClick={state.generateBugReportZStream}
+                />
+            </StackItem>
+
+            <StackItem>
+                <Stack
+                    horizontal
+                    verticalAlign="center"
+                    tokens={{ childrenGap: 8 }}
+                >
+                    <StackItem>
+                        <PrimaryButton
+                            disabled={
+                                !state.bugReport?.supportsBugReportZ ||
+                                state.bugReportZInProgress
+                            }
+                            text="Generate Zipped BugReport"
+                            onClick={state.generateBugReportZ}
+                        />
+                    </StackItem>
+
+                    {state.bugReportZInProgress && (
+                        <StackItem>
+                            {state.bugReportZTotalSize ? (
+                                <span>
+                                    Progress: {state.bugReportZProgress} /{" "}
+                                    {state.bugReportZTotalSize}
+                                </span>
+                            ) : (
+                                <span>
+                                    Generating... Please wait
+                                    {!state.bugReport!
+                                        .supportsBugReportZProgress &&
+                                        " (this device does not support progress)"}
+                                </span>
+                            )}
+                        </StackItem>
+                    )}
+                </Stack>
+            </StackItem>
+        </Stack>
+    );
+};
+
+export default observer(BugReportPage);

--- a/packages/demo/src/pages/chrome-devtools-frame.tsx
+++ b/packages/demo/src/pages/chrome-devtools-frame.tsx
@@ -1,0 +1,124 @@
+import { Stack } from "@fluentui/react";
+import { makeStyles } from "@griffel/react";
+import { useEffect } from "react";
+
+const useClasses = makeStyles({
+    body: {
+        "@media (prefers-color-scheme: dark)": {
+            backgroundColor: "rgb(41, 42, 45)",
+            color: "#ddd",
+        },
+    },
+});
+
+function ChromeDevToolsFrame() {
+    const classes = useClasses();
+
+    useEffect(() => {
+        var WebSocketOriginal = globalThis.WebSocket;
+        globalThis.WebSocket = class WebSocket extends EventTarget {
+            public static readonly CONNECTING: 0 = 0;
+            public static readonly OPEN: 1 = 1;
+            public static readonly CLOSING: 2 = 2;
+            public static readonly CLOSED: 3 = 3;
+
+            public readonly CONNECTING: 0 = 0;
+            public readonly OPEN: 1 = 1;
+            public readonly CLOSING: 2 = 2;
+            public readonly CLOSED: 3 = 3;
+
+            public binaryType: BinaryType = "arraybuffer";
+            public readonly bufferedAmount: number = 0;
+            public readonly extensions: string = "";
+
+            public readonly protocol: string = "";
+            public readonly readyState: number = 1;
+            public readonly url: string;
+
+            private _port: MessagePort;
+
+            public onclose: ((this: WebSocket, ev: CloseEvent) => any) | null =
+                null;
+            /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebSocket/error_event) */
+            public onerror: ((this: WebSocket, ev: Event) => any) | null = null;
+            /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebSocket/message_event) */
+            public onmessage:
+                | ((this: WebSocket, ev: MessageEvent) => any)
+                | null = null;
+            /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebSocket/open_event) */
+            public onopen: ((this: WebSocket, ev: Event) => any) | null = null;
+
+            constructor(url: string) {
+                super();
+
+                console.log("WebSocket constructor", url);
+                this.url = url;
+
+                var channel = new MessageChannel();
+                this._port = channel.port1;
+
+                if (url.includes("/_next/")) {
+                    this._port.close();
+                    // @ts-ignore
+                    return new WebSocketOriginal(url);
+                }
+
+                this._port.onmessage = (e) => {
+                    switch (e.data.type) {
+                        case "open":
+                            this.onopen?.(new Event("open"));
+                            break;
+                        case "message":
+                            this.onmessage?.(
+                                new MessageEvent("message", {
+                                    data: e.data.message,
+                                })
+                            );
+                            break;
+                        case "close":
+                            this.onclose?.(new CloseEvent("close"));
+                            this._port.close();
+                            break;
+                    }
+                };
+                globalThis.postMessage({ type: "AdbWebSocket", url }, "*", [
+                    channel.port2,
+                ]);
+            }
+
+            send(data: ArrayBuffer) {
+                this._port.postMessage({ type: "message", message: data });
+            }
+
+            public close() {
+                this._port.postMessage({ type: "close" });
+                this._port.close();
+            }
+        } as typeof WebSocket;
+        console.log("WebSocket hooked");
+
+        const script = document.createElement("script");
+        script.type = "module";
+        script.src = new URLSearchParams(location.search).get(
+            "script"
+        ) as string;
+        document.body.appendChild(script);
+    }, []);
+
+    // DevTools will set `document.title` to debugged page's title.
+    return (
+        <Stack
+            className={classes.body}
+            verticalFill
+            verticalAlign="center"
+            horizontalAlign="center"
+        >
+            <div>Loading DevTools...</div>
+            <div>(requires network connection)</div>
+        </Stack>
+    );
+}
+
+ChromeDevToolsFrame.noLayout = true;
+
+export default ChromeDevToolsFrame;

--- a/packages/demo/src/pages/chrome-devtools.tsx
+++ b/packages/demo/src/pages/chrome-devtools.tsx
@@ -1,0 +1,459 @@
+import { Link, Stack } from "@fluentui/react";
+import { makeStyles } from "@griffel/react";
+import { AdbSocket } from "@yume-chan/adb";
+import {
+    Consumable,
+    ReadableStreamDefaultReader,
+    WritableStreamDefaultWriter,
+} from "@yume-chan/stream-extra";
+import {
+    Agent,
+    Client,
+    Duplex,
+    Pool,
+    Symbols,
+    WebSocket,
+    request,
+} from "@yume-chan/undici-browser";
+import {
+    action,
+    makeAutoObservable,
+    observable,
+    reaction,
+    runInAction,
+} from "mobx";
+import { observer } from "mobx-react-lite";
+import { NextPage } from "next";
+import getConfig from "next/config";
+import Head from "next/head";
+import type { Socket } from "node:net";
+import { useCallback, useEffect } from "react";
+import { GLOBAL_STATE } from "../state";
+import { RouteStackProps } from "../utils";
+
+class AdbUndiciSocket extends Duplex {
+    private _socket: AdbSocket;
+    private _reader: ReadableStreamDefaultReader<Uint8Array>;
+    private _writer: WritableStreamDefaultWriter<Consumable<Uint8Array>>;
+
+    constructor(socket: AdbSocket) {
+        super();
+        this._socket = socket;
+        this._reader = this._socket.readable.getReader();
+        this._writer = this._socket.writable.getWriter();
+        this._reader.closed.then(() => this.emit("end"));
+    }
+
+    async _read(size: number): Promise<void> {
+        try {
+            const result = await this._reader.read();
+            if (result.done) {
+                this.emit("end");
+            } else {
+                this.push(result.value);
+            }
+        } catch {
+            //ignore
+        }
+    }
+
+    async _write(
+        chunk: any,
+        encoding: BufferEncoding,
+        callback: (error?: Error | null | undefined) => void
+    ): Promise<void> {
+        const consumable = new Consumable(chunk);
+        try {
+            await this._writer.write(consumable);
+            callback();
+        } catch (e) {
+            callback(e as Error);
+        }
+    }
+
+    async _destroy(
+        error: Error | null,
+        callback: (error: Error | null) => void
+    ): Promise<void> {
+        await this._socket.close();
+        callback(error);
+    }
+}
+
+const agent = new Agent({
+    factory(origin, opts) {
+        const pool = new Pool(origin, {
+            ...opts,
+            factory(origin, opts) {
+                const client = new Client(origin, opts);
+                // Remote debugging validates `Host` header to defend against DNS rebinding attacks.
+                // But we can only pass socket name using hostname, so we need to override it.
+                (client as any)[Symbols.kHostHeader] = "Host: localhost\r\n";
+                return client;
+            },
+        });
+        return pool;
+    },
+    async connect(options, callback) {
+        try {
+            const socket = await GLOBAL_STATE.adb!.createSocket(
+                "localabstract:" + options.hostname
+            );
+            callback(null, new AdbUndiciSocket(socket) as unknown as Socket);
+        } catch (e) {
+            callback(e as Error, null);
+        }
+    },
+});
+
+interface Page {
+    description: string;
+    devtoolsFrontendUrl: string;
+    id: string;
+    title: string;
+    type: string;
+    url: string;
+    webSocketDebuggerUrl: string;
+}
+
+interface Version {
+    "Android-Package": string;
+    Browser: string;
+    "Protocol-Version": string;
+    "User-Agent": string;
+    "V8-Version": string;
+    "WebKit-Version": string;
+    webSocketDebuggerUrl: string;
+}
+
+// https://source.chromium.org/chromium/chromium/src/+/refs/heads/main:chrome/browser/devtools/device/devtools_device_discovery.cc;l=36;drc=4651cec294d1542d6673a89190e192e20de03240
+
+async function getPages(socket: string) {
+    const response = await request(`http://${socket}/json`, {
+        dispatcher: agent,
+    });
+    const body = await response.body.json();
+    return body as Page[];
+}
+
+async function getVersion(socket: string) {
+    const response = await request(`http://${socket}/json/version`, {
+        dispatcher: agent,
+    });
+    const body = await response.body.json();
+    return body as Version;
+}
+
+async function focusPage(socket: string, page: Page) {
+    await request(`http://${socket}/json/activate/${page.id}`, {
+        dispatcher: agent,
+    });
+}
+
+async function closePage(socket: string, page: Page) {
+    await request(`http://${socket}/json/close/${page.id}`, {
+        dispatcher: agent,
+    });
+}
+
+const {
+    publicRuntimeConfig: { basePath },
+} = getConfig();
+
+// Use a fixed version from Chrome's distribution, updated regularly.
+// Opera: doesn't host its own frontend
+// Edge: only have versions for Canary version, have license issues
+// Brave: `frontendUrl` points to Google's but version number is invalid
+const FRONTEND_SCRIPT =
+    "https://chrome-devtools-frontend.appspot.com/serve_internal_file/@3c3641f7c28cf564edd441cc4ca2838b32c4e52a/front_end/entrypoints/inspector/inspector.js";
+
+function getPopupParams(page: Page) {
+    const frontendUrl = page.devtoolsFrontendUrl;
+    const [, params] = frontendUrl.split("?");
+    return {
+        script: FRONTEND_SCRIPT,
+        params,
+    };
+}
+
+interface Browser {
+    socket: string;
+    version: Version;
+    pages: Page[];
+}
+
+const STATE = makeAutoObservable(
+    {
+        browsers: [] as Browser[],
+        intervalId: null as NodeJS.Timeout | null,
+        visible: false,
+    },
+    {
+        browsers: observable.deep,
+    }
+);
+
+const SOCKET_NAMES = [
+    "@(.*)_devtools_remote(_\\d+)?",
+    "@com\\.opera\\.browser(\\.beta)?\\.devtools",
+];
+
+const GET_SOCKET_COMMAND = [
+    "cat /proc/net/unix",
+    `grep -E "${SOCKET_NAMES.join("|")}"`,
+    "awk '{print substr($8, 2)}'",
+];
+
+async function getBrowsers() {
+    const device = GLOBAL_STATE.adb!;
+    const sockets = await device.subprocess.spawnAndWaitLegacy(
+        GET_SOCKET_COMMAND.join(" | ")
+    );
+    const browsers: Browser[] = [];
+    for (const socket of sockets.split("\n").filter(Boolean)) {
+        if (browsers.some((browser) => browser.socket == socket)) {
+            continue;
+        }
+
+        try {
+            const version = await getVersion(socket);
+            const pages = await getPages(socket);
+            console.log(socket, version, pages);
+            browsers.push({ socket, version, pages });
+        } catch (e) {
+            console.error(socket, e);
+        }
+    }
+    runInAction(() => {
+        STATE.browsers = browsers;
+    });
+}
+
+reaction(
+    () => [GLOBAL_STATE.adb, STATE.visible] as const,
+    ([device, visible]) => {
+        if (!device || !visible) {
+            STATE.browsers = [];
+            if (STATE.intervalId) {
+                clearInterval(STATE.intervalId);
+                STATE.intervalId = null;
+            }
+            return;
+        }
+
+        STATE.intervalId = setInterval(() => {
+            getBrowsers();
+        }, 5000);
+
+        getBrowsers();
+    }
+);
+
+const PACKAGE_NAMES: Record<string, string | undefined> = {
+    "com.android.chrome": "Google Chrome",
+    "com.chrome.beta": "Google Chrome Beta",
+    "com.chrome.dev": "Google Chrome Dev",
+    "com.chrome.canary": "Google Chrome Canary",
+    "com.microsoft.emmx": "Microsoft Edge",
+    "com.microsoft.emmx.beta": "Microsoft Edge Beta",
+    "com.microsoft.emmx.dev": "Microsoft Edge Dev",
+    "com.microsoft.emmx.canary": "Microsoft Edge Canary",
+    "com.opera.browser": "Opera",
+    "com.opera.browser.beta": "Opera Beta",
+    "com.vivaldi.browser": "Vivaldi",
+};
+
+function getBrowserName(version: Version) {
+    const [, versionNumber] = version.Browser.split("/");
+    const name =
+        PACKAGE_NAMES[version["Android-Package"]] || version["Android-Package"];
+    return `${name} (${versionNumber})`;
+}
+
+const useClasses = makeStyles({
+    header: {
+        marginTop: "4px",
+        marginBottom: "4px",
+    },
+    url: {
+        marginLeft: "8px",
+        color: "#999",
+    },
+    link: {
+        marginRight: "12px",
+    },
+});
+
+const ChromeDevToolsPage: NextPage = observer(function ChromeDevTools() {
+    const classes = useClasses();
+
+    useEffect(() => {
+        runInAction(() => {
+            STATE.visible = true;
+        });
+
+        return action(() => {
+            STATE.visible = false;
+        });
+    }, []);
+
+    const handleInspectClick = useCallback((socket: string, page: Page) => {
+        const { script, params } = getPopupParams(page);
+        const childWindow = window.open(
+            `${basePath}/chrome-devtools-frame?script=${script}&${params}`,
+            "_blank",
+            "popup"
+        )!;
+        childWindow.addEventListener("message", (e) => {
+            if (
+                typeof e.data !== "object" ||
+                e.data === null ||
+                !("type" in e.data) ||
+                (e.data as any).type !== "AdbWebSocket"
+            ) {
+                return;
+            }
+
+            const url = new URL(e.data.url as string);
+            url.host = socket;
+
+            const port = e.ports[0];
+
+            const ws = new WebSocket(url, {
+                dispatcher: agent,
+            });
+            ws.binaryType = "arraybuffer";
+            ws.onopen = () => {
+                port.postMessage({ type: "open" });
+            };
+            ws.onclose = () => {
+                port.postMessage({ type: "close" });
+                port.close();
+            };
+            ws.onmessage = (e) => {
+                const { data } = e;
+                port.postMessage({
+                    type: "message",
+                    message: data,
+                });
+            };
+
+            port.onmessage = (e) => {
+                switch (e.data.type) {
+                    case "message":
+                        ws.send(e.data.message);
+                        break;
+                    case "close":
+                        ws.close();
+                        break;
+                }
+            };
+
+            childWindow.addEventListener("close", () => {
+                ws.close();
+            });
+
+            globalThis.addEventListener("beforeunload", () => {
+                port.postMessage({ type: "close" });
+                port.close();
+            });
+        });
+    }, []);
+
+    const handleFocusClick = useCallback((socket: string, page: Page) => {
+        focusPage(socket, page);
+    }, []);
+
+    const handleCloseClick = useCallback((socket: string, page: Page) => {
+        closePage(socket, page);
+        getBrowsers();
+    }, []);
+
+    return (
+        <Stack {...RouteStackProps}>
+            <Head>
+                <title>Chrome Remote Debugging - Tango</title>
+            </Head>
+
+            {STATE.browsers.length === 0 ? (
+                <>
+                    <h2>Supported browsers:</h2>
+                    <ul>
+                        <li>Google Chrome (stable/beta/dev/canary)</li>
+                        <li>Microsoft Edge (stable/beta/dev/canary)</li>
+                        <li>Opera (stable/beta)</li>
+                        <li>Vivaldi</li>
+                        <li>Any WebView with remote debugging on</li>
+                    </ul>
+                </>
+            ) : (
+                STATE.browsers.map((browser) => (
+                    <>
+                        {browser.version && (
+                            <h3 className={classes.header}>
+                                {getBrowserName(browser.version)}
+                            </h3>
+                        )}
+
+                        {browser.pages.map((page) => (
+                            <div key={page.id}>
+                                <div>
+                                    {page.title ? (
+                                        <span
+                                            dangerouslySetInnerHTML={{
+                                                __html: page.title,
+                                            }}
+                                        />
+                                    ) : (
+                                        <i>No Title</i>
+                                    )}
+
+                                    <span className={classes.url}>
+                                        {page.url || <i>No URL</i>}
+                                    </span>
+                                </div>
+                                <div>
+                                    <Link
+                                        className={classes.link}
+                                        onClick={() =>
+                                            handleInspectClick(
+                                                browser.socket,
+                                                page
+                                            )
+                                        }
+                                    >
+                                        Inspect
+                                    </Link>
+                                    <Link
+                                        className={classes.link}
+                                        onClick={() =>
+                                            handleFocusClick(
+                                                browser.socket,
+                                                page
+                                            )
+                                        }
+                                    >
+                                        Focus
+                                    </Link>
+                                    <Link
+                                        className={classes.link}
+                                        onClick={() =>
+                                            handleCloseClick(
+                                                browser.socket,
+                                                page
+                                            )
+                                        }
+                                    >
+                                        Close
+                                    </Link>
+                                </div>
+                            </div>
+                        ))}
+                    </>
+                ))
+            )}
+        </Stack>
+    );
+});
+
+export default ChromeDevToolsPage;

--- a/packages/demo/src/pages/device-info.tsx
+++ b/packages/demo/src/pages/device-info.tsx
@@ -6,7 +6,6 @@ import {
     TooltipHost,
 } from "@fluentui/react";
 import { AdbFeature } from "@yume-chan/adb";
-import { BugReportPanel, InstallApkPanel, PowerPanel } from "../components";
 import { observer } from "mobx-react-lite";
 import type { NextPage } from "next";
 import Head from "next/head";
@@ -100,26 +99,6 @@ const DeviceInfo: NextPage = () => {
                     </span>
                 ))}
             </span>
-
-            <Separator />
-
-            <Stack tokens={{ childrenGap: 16 }}>
-                <Stack>
-                    <InstallApkPanel />
-                </Stack>
-
-                <Separator />
-
-                <Stack>
-                    <PowerPanel />
-                </Stack>
-
-                <Separator />
-
-                <Stack>
-                    <BugReportPanel />
-                </Stack>
-            </Stack>
         </Stack>
     );
 };

--- a/packages/demo/src/pages/index.mdx
+++ b/packages/demo/src/pages/index.mdx
@@ -50,6 +50,7 @@ Extra software is required to bridge the connection. See <ExternalLink href="htt
 
 ## URL parameters
 
+- ws=ws://host:port or wss://host/path: Overrides the WebSocket server for this page load. The value is URL-decoded, and must start with ws:// or wss://. Invalid values are ignored and the default behavior remains in effect.
 - showSidebar=true|false: Controls visibility of the left sidebar. Values are case-insensitive. When absent or invalid, the app uses its existing default behavior.
 
 >>>>>>> c0ddce3 (feat(demo): support ?ws= query param to override WebSocket server for current page load\n\n- Parse window.location.search for ws parameter\n- Validate scheme is ws: or wss:; ignore invalid values\n- No persistence beyond current page load\n\nCo-authored-by: phorcys420 <57866459+phorcys420@users.noreply.github.com>)

--- a/packages/demo/src/pages/index.mdx
+++ b/packages/demo/src/pages/index.mdx
@@ -52,6 +52,7 @@ Extra software is required to bridge the connection. See <ExternalLink href="htt
 
 - showSidebar=true|false: Controls visibility of the left sidebar. Values are case-insensitive. When absent or invalid, the app uses its existing default behavior.
 
+>>>>>>> c0ddce3 (feat(demo): support ?ws= query param to override WebSocket server for current page load\n\n- Parse window.location.search for ws parameter\n- Validate scheme is ws: or wss:; ignore invalid values\n- No persistence beyond current page load\n\nCo-authored-by: phorcys420 <57866459+phorcys420@users.noreply.github.com>)
 export default ({ children }) => (
     <div style={{ height: "100%", padding: "0 16px", overflow: "auto" }}>
         <Head>

--- a/packages/demo/src/pages/install.tsx
+++ b/packages/demo/src/pages/install.tsx
@@ -1,0 +1,188 @@
+import {
+    Checkbox,
+    PrimaryButton,
+    ProgressIndicator,
+    Stack,
+} from "@fluentui/react";
+import {
+    PackageManager,
+    PackageManagerInstallOptions,
+} from "@yume-chan/android-bin";
+import { WrapConsumableStream, WritableStream } from "@yume-chan/stream-extra";
+import { action, makeAutoObservable, observable, runInAction } from "mobx";
+import { observer } from "mobx-react-lite";
+import { NextPage } from "next";
+import Head from "next/head";
+import { GLOBAL_STATE } from "../state";
+import {
+    ProgressStream,
+    RouteStackProps,
+    createFileStream,
+    pickFile,
+} from "../utils";
+
+enum Stage {
+    Uploading,
+
+    Installing,
+
+    Completed,
+}
+
+interface Progress {
+    filename: string;
+
+    stage: Stage;
+
+    uploadedSize: number;
+
+    totalSize: number;
+
+    value: number | undefined;
+}
+
+class InstallPageState {
+    installing = false;
+
+    progress: Progress | undefined = undefined;
+
+    log: string = "";
+
+    options: Partial<PackageManagerInstallOptions> = {
+        bypassLowTargetSdkBlock: false,
+    };
+
+    constructor() {
+        makeAutoObservable(this, {
+            progress: observable.ref,
+            install: false,
+            options: observable.deep,
+        });
+    }
+
+    install = async () => {
+        const file = await pickFile({ accept: ".apk" });
+        if (!file) {
+            return;
+        }
+
+        runInAction(() => {
+            this.installing = true;
+            this.progress = {
+                filename: file.name,
+                stage: Stage.Uploading,
+                uploadedSize: 0,
+                totalSize: file.size,
+                value: 0,
+            };
+            this.log = "";
+        });
+
+        const pm = new PackageManager(GLOBAL_STATE.adb!);
+        const start = Date.now();
+        const log = await pm.installStream(
+            file.size,
+            createFileStream(file)
+                .pipeThrough(new WrapConsumableStream())
+                .pipeThrough(
+                    new ProgressStream(
+                        action((uploaded) => {
+                            if (uploaded !== file.size) {
+                                this.progress = {
+                                    filename: file.name,
+                                    stage: Stage.Uploading,
+                                    uploadedSize: uploaded,
+                                    totalSize: file.size,
+                                    value: (uploaded / file.size) * 0.8,
+                                };
+                            } else {
+                                this.progress = {
+                                    filename: file.name,
+                                    stage: Stage.Installing,
+                                    uploadedSize: uploaded,
+                                    totalSize: file.size,
+                                    value: 0.8,
+                                };
+                            }
+                        })
+                    )
+                )
+        );
+
+        const elapsed = Date.now() - start;
+        await log.pipeTo(
+            new WritableStream({
+                write: action((chunk) => {
+                    this.log += chunk;
+                }),
+            })
+        );
+
+        const transferRate = (
+            file.size /
+            (elapsed / 1000) /
+            1024 /
+            1024
+        ).toFixed(2);
+        this.log += `Install finished in ${elapsed}ms at ${transferRate}MB/s`;
+
+        runInAction(() => {
+            this.progress = {
+                filename: file.name,
+                stage: Stage.Completed,
+                uploadedSize: file.size,
+                totalSize: file.size,
+                value: 1,
+            };
+            this.installing = false;
+        });
+    };
+}
+
+const state = new InstallPageState();
+
+const Install: NextPage = () => {
+    return (
+        <Stack {...RouteStackProps}>
+            <Head>
+                <title>Install APK - Tango</title>
+            </Head>
+
+            <Stack horizontal>
+                <Checkbox
+                    label="--bypass-low-target-sdk-block (Android 14)"
+                    checked={state.options.bypassLowTargetSdkBlock}
+                    onChange={(_, checked) => {
+                        if (checked === undefined) {
+                            return;
+                        }
+                        runInAction(() => {
+                            state.options.bypassLowTargetSdkBlock = checked;
+                        });
+                    }}
+                />
+            </Stack>
+
+            <Stack horizontal>
+                <PrimaryButton
+                    disabled={!GLOBAL_STATE.adb || state.installing}
+                    text="Browse APK"
+                    onClick={state.install}
+                />
+            </Stack>
+
+            {state.progress && (
+                <ProgressIndicator
+                    styles={{ root: { width: 300 } }}
+                    label={state.progress.filename}
+                    percentComplete={state.progress.value}
+                    description={Stage[state.progress.stage]}
+                />
+            )}
+
+            {state.log && <pre>{state.log}</pre>}
+        </Stack>
+    );
+};
+
+export default observer(Install);

--- a/packages/demo/src/pages/power.tsx
+++ b/packages/demo/src/pages/power.tsx
@@ -1,0 +1,133 @@
+// cspell: ignore bootloader
+// cspell: ignore fastboot
+
+import {
+    DefaultButton,
+    Icon,
+    MessageBar,
+    MessageBarType,
+    Stack,
+    TooltipHost,
+} from "@fluentui/react";
+import { observer } from "mobx-react-lite";
+import { NextPage } from "next";
+import Head from "next/head";
+import { GLOBAL_STATE } from "../state";
+import { Icons, RouteStackProps } from "../utils";
+
+const Power: NextPage = () => {
+    return (
+        <Stack {...RouteStackProps}>
+            <Head>
+                <title>Power Menu - Tango</title>
+            </Head>
+
+            <div>
+                <DefaultButton
+                    text="Reboot"
+                    disabled={!GLOBAL_STATE.adb}
+                    onClick={() => GLOBAL_STATE.adb!.power.reboot()}
+                />
+            </div>
+
+            <div style={{ marginTop: 20 }}>
+                <DefaultButton
+                    text="Power Off"
+                    disabled={!GLOBAL_STATE.adb}
+                    onClick={() => GLOBAL_STATE.adb!.power.powerOff()}
+                />
+            </div>
+
+            <div style={{ marginTop: 20 }}>
+                <DefaultButton
+                    text="Press Power Button"
+                    disabled={!GLOBAL_STATE.adb}
+                    onClick={() => GLOBAL_STATE.adb!.power.powerButton()}
+                />
+            </div>
+
+            <div style={{ marginTop: 20 }}>
+                <MessageBar
+                    messageBarType={MessageBarType.severeWarning}
+                    delayedRender={false}
+                >
+                    Danger Zone Below
+                </MessageBar>
+            </div>
+
+            <div style={{ marginTop: 20 }}>
+                <DefaultButton
+                    text="Reboot to Bootloader"
+                    disabled={!GLOBAL_STATE.adb}
+                    onClick={() => GLOBAL_STATE.adb!.power.bootloader()}
+                />
+            </div>
+
+            <div style={{ marginTop: 20 }}>
+                <DefaultButton
+                    text="Reboot to Fastboot"
+                    disabled={!GLOBAL_STATE.adb}
+                    onClick={() => GLOBAL_STATE.adb!.power.fastboot()}
+                />
+            </div>
+
+            <div style={{ marginTop: 20 }}>
+                <DefaultButton
+                    text="Reboot to Recovery"
+                    disabled={!GLOBAL_STATE.adb}
+                    onClick={() => GLOBAL_STATE.adb!.power.recovery()}
+                />
+            </div>
+
+            <div style={{ marginTop: 20 }}>
+                <DefaultButton
+                    text="Reboot to Sideload"
+                    disabled={!GLOBAL_STATE.adb}
+                    onClick={() => GLOBAL_STATE.adb!.power.sideload()}
+                />
+            </div>
+
+            <div style={{ marginTop: 20 }}>
+                <DefaultButton
+                    text="Reboot to Qualcomm EDL Mode"
+                    disabled={!GLOBAL_STATE.adb}
+                    onClick={() => GLOBAL_STATE.adb!.power.qualcommEdlMode()}
+                />
+                <TooltipHost
+                    content={<span>Only works on some Qualcomm devices.</span>}
+                >
+                    <Icon
+                        style={{
+                            verticalAlign: "middle",
+                            marginLeft: 4,
+                            fontSize: 18,
+                        }}
+                        iconName={Icons.Info}
+                    />
+                </TooltipHost>
+            </div>
+
+            <div style={{ marginTop: 20 }}>
+                <DefaultButton
+                    text="Reboot to Samsung Odin Download Mode"
+                    disabled={!GLOBAL_STATE.adb}
+                    onClick={() => GLOBAL_STATE.adb!.power.samsungOdin()}
+                />
+                <TooltipHost
+                    content={<span>Only works on Samsung devices.</span>}
+                >
+                    <Icon
+                        style={{
+                            verticalAlign: "middle",
+                            marginLeft: 4,
+                            fontSize: 18,
+                        }}
+                        iconName={Icons.Info}
+                    />
+                </TooltipHost>
+            </div>
+        </Stack>
+    );
+};
+
+export default observer(Power);


### PR DESCRIPTION
This PR adds support for overriding the WebSocket server via a URL query parameter for the demo app.

Summary
- Parameter name: `ws`
- Examples: `?ws=wss://example.com/socket` or `?ws=ws://localhost:8080`
- Parsing occurs early in app initialization within the Connect component, before any socket connection is created. When valid, a temporary WebSocket device is added and auto-selected; it will auto-connect on page load.
- The value is URL-decoded and validated to ensure the scheme is `ws:` or `wss:`. Invalid values are ignored so the existing default behavior remains unchanged.
- Persisted only for this page load (no changes to storage), unless the user manually saves a server using the existing UI.

Docs
- Updated the URL parameters section to document the new `ws` parameter and its behavior.

Tests
- No existing unit test harness was found in the repo for config parsing, so no new unit tests were added.

Acceptance
- When provided and valid, the app attempts to connect to the specified WebSocket endpoint.
- When not provided or invalid, behavior is unchanged and safe fallback is used.