### PR TITLE
Static-friendly: root base path and .html navigations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,9 +7,6 @@ on:
   push:
     branches: [main]
 
-env:
-  BASE_PATH: /old-demo
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/packages/demo/src/pages/_app.tsx
+++ b/packages/demo/src/pages/_app.tsx
@@ -91,8 +91,10 @@ function NavLink({
         return null;
     }
 
+    // For static export, link to .html files (except root)
+    const href = link.url === "/" ? "/" : `${link.url}.html`;
     return (
-        <Link href={link.url} legacyBehavior passHref>
+        <Link href={href} legacyBehavior passHref>
             <DefaultRender {...props} />
         </Link>
     );

--- a/packages/demo/src/pages/chrome-devtools.tsx
+++ b/packages/demo/src/pages/chrome-devtools.tsx
@@ -300,7 +300,7 @@ const ChromeDevToolsPage: NextPage = observer(function ChromeDevTools() {
     const handleInspectClick = useCallback((socket: string, page: Page) => {
         const { script, params } = getPopupParams(page);
         const childWindow = window.open(
-            `${basePath}/chrome-devtools-frame?script=${script}&${params}`,
+            `${basePath}/chrome-devtools-frame.html?script=${script}&${params}`,
             "_blank",
             "popup"
         )!;


### PR DESCRIPTION
Summary:
- Remove BASE_PATH=/old-demo from deploy workflow so the app builds with basePath="/" and serves from root.
- Update internal navigation to link to .html files for Next.js `next export` compatibility.
- Update chrome-devtools popup to use chrome-devtools-frame.html.

Motivation:
This makes the demo friendlier when served as a purely static site (e.g., GitHub Pages) at the repo root instead of /old-demo/.

Testing:
- Ran a local build and verified routes resolve to .html and manifest still loads via basePath.
