### PR TITLE
CI: build website on pull requests

### DIFF
--- a/.github/workflows/website-build.yml
+++ b/.github/workflows/website-build.yml
@@ -1,0 +1,28 @@
+name: Website build
+
+on:
+  pull_request:
+    branches: [ '**' ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - name: Install deps (workspace)
+        run: pnpm install --frozen-lockfile=false
+      - name: Build demo
+        working-directory: packages/demo
+        run: pnpm build


### PR DESCRIPTION
What
- Adds a GitHub Actions workflow to install workspace deps with pnpm and run `pnpm build` for packages/demo on pull_request.

Why
- Ensures PRs don’t regress the website build.

Details
- Node 20, pnpm 10, caches pnpm.
- Runs on every PR targeting any branch (branches: ['**']).

If you want this to trigger only for PRs into main, I can narrow the trigger to `branches: [ 'main' ]`.