### PR TITLE
CI: run deploy workflow on PRs (build only, no upload/deploy)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,8 @@ permissions:
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: ["**"]
 
 jobs:
   build:
@@ -33,13 +35,14 @@ jobs:
       - run: touch packages/demo/out/.nojekyll
 
       - name: Upload static site artifact
-        if: ${{ success() }}
+        if: ${{ success() && github.event_name == 'push' }}
         uses: actions/upload-artifact@v4
         with:
           name: adb-tools-static-site
           path: packages/demo/out
 
       - name: Deploy
+        if: ${{ github.event_name == 'push' }}
         uses: s0/git-publish-subdir-action@develop
         env:
           REPO: self


### PR DESCRIPTION
What
- Update .github/workflows/deploy.yml to also run on pull_request and perform build/export checks, but skip artifact upload and deployment on PRs.

Why
- Ensures deploy pipeline remains green for changes while avoiding pushing artifacts or publishing from PRs.

Details
- Added pull_request trigger.
- Conditioned upload-artifact and deploy steps to run only on push.
- Keeps Node 18 + pnpm 8 versions from the current deploy job.
