### PR TITLE
file-manager: preserve pathname (.html) and query params when updating path

### DIFF
--- a/packages/demo/src/pages/file-manager.tsx
+++ b/packages/demo/src/pages/file-manager.tsx
@@ -586,7 +586,12 @@ class FileManagerState {
     }
 
     pushPathQuery = (path: string) => {
-        Router.push({ query: { ...Router.query, path } });
+        if (typeof window === "undefined") return;
+        const url = new URL(window.location.href);
+        url.searchParams.set("path", path);
+        // Preserve pathname (including .html) and all other params
+        const next = url.pathname + (url.search ? url.search : "");
+        Router.replace(next);
     };
 
     changeDirectory(path: string) {
@@ -785,7 +790,12 @@ const FileManager: NextPage = (): JSX.Element | null => {
     useEffect(() => {
         let pathQuery = router.query.path;
         if (!pathQuery) {
-            router.replace({ query: { ...router.query, path: state.path } });
+            if (typeof window !== "undefined") {
+                const url = new URL(window.location.href);
+                url.searchParams.set("path", state.path);
+                const next = url.pathname + (url.search ? url.search : "");
+                router.replace(next);
+            }
             return;
         }
 


### PR DESCRIPTION
Problem
- The file manager updates the `?path` query via object-based router.push/replace, which can drop other query parameters and lose the `.html` pathname when the site is served as a static export.

Fix
- Switch to string-based replace using the current URL, updating only the `path` search param and preserving:
  - the existing pathname (including .html when applicable)
  - all other query parameters

Code
- packages/demo/src/pages/file-manager.tsx
  - pushPathQuery now uses URL + Router.replace(next)
  - initial path injection also uses the same approach

Result
- Navigating directories in File Manager no longer strips existing query parameters or resets the pathname.
